### PR TITLE
Added distinctMultiaddr method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const Id = require('peer-id')
 const multiaddr = require('multiaddr')
+const _ = require('lodash')
 
 exports = module.exports = PeerInfo
 
@@ -86,6 +87,13 @@ function PeerInfo (peerId) {
     fresh.forEach((m) => {
       this.multiaddr.add(m)
     })
+  }
+
+  this.distinctMultiaddr = () => {
+    var result = _.uniqBy(this.multiaddrs, function (item) {
+      return item.toOptions().port
+    })
+    return result
   }
 
   // TODO: add features to fetch multiaddr using filters

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const Id = require('peer-id')
 const multiaddr = require('multiaddr')
-const _ = require('lodash')
+const uniqBy = require('lodash').uniqBy
 
 exports = module.exports = PeerInfo
 
@@ -90,7 +90,7 @@ function PeerInfo (peerId) {
   }
 
   this.distinctMultiaddr = () => {
-    var result = _.uniqBy(this.multiaddrs, function (item) {
+    var result = uniqBy(this.multiaddrs, function (item) {
       return [item.toOptions().port, item.toOptions().transport].join()
     })
     return result

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ function PeerInfo (peerId) {
 
   this.distinctMultiaddr = () => {
     var result = _.uniqBy(this.multiaddrs, function (item) {
-      return item.toOptions().port
+      return [item.toOptions().port, item.toOptions().transport].join()
     })
     return result
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -151,4 +151,81 @@ describe('peer-info', () => {
 
     expect(pi.multiaddrs.length).to.equal(4)
   })
+
+  it('get distinct multiaddr same transport multiple different ports', () => {
+    const mh1 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const mh2 = Multiaddr('/ip4/127.0.0.1/tcp/5002')
+    const mh3 = Multiaddr('/ip4/127.0.0.1/tcp/5003')
+    const mh4 = Multiaddr('/ip4/127.0.0.1/tcp/5004')
+
+    pi.multiaddr.add(mh1)
+    pi.multiaddr.add(mh2)
+    pi.multiaddr.add(mh3)
+    pi.multiaddr.add(mh4)
+
+    var distinctMultiaddr = pi.distinctMultiaddr()
+    expect(distinctMultiaddr.length).to.equal(4)
+  })
+
+  it('get distinct multiaddr same transport different port', () => {
+    const mh1 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const mh2 = Multiaddr('/ip4/127.0.0.1/tcp/5002')
+
+    pi.multiaddr.add(mh1)
+    pi.multiaddr.add(mh2)
+
+    var distinctMultiaddr = pi.distinctMultiaddr()
+    expect(distinctMultiaddr.length).to.equal(2)
+  })
+
+  it('get distinct multiaddr same transport same port', () => {
+    const mh1 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const mh2 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+
+    pi.multiaddr.add(mh1)
+    pi.multiaddr.add(mh2)
+
+    var distinctMultiaddr = pi.distinctMultiaddr()
+    expect(distinctMultiaddr.length).to.equal(1)
+  })
+
+  it('get distinct multiaddr different transport same port', () => {
+    const mh1 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const mh2 = Multiaddr('/ip4/127.0.0.1/udp/5001')
+
+    pi.multiaddr.add(mh1)
+    pi.multiaddr.add(mh2)
+
+    var distinctMultiaddr = pi.distinctMultiaddr()
+    expect(distinctMultiaddr.length).to.equal(2)
+  })
+
+  it('get distinct multiaddr different family same port same transport', () => {
+    const mh1 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const mh2 = Multiaddr('/ip6/::/tcp/5001')
+
+    pi.multiaddr.add(mh1)
+    pi.multiaddr.add(mh2)
+
+    var distinctMultiaddr = pi.distinctMultiaddr()
+    expect(distinctMultiaddr.length).to.equal(1)
+  })
+
+  it('get distinct multiaddr different family same port multiple transports', () => {
+    const mh1 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const mh2 = Multiaddr('/ip6/::/tcp/5001')
+    const mh3 = Multiaddr('/ip6/::/udp/5002')
+    const mh4 = Multiaddr('/ip4/127.0.0.1/udp/5002')
+
+    pi.multiaddr.add(mh1)
+    pi.multiaddr.add(mh2)
+    pi.multiaddr.add(mh3)
+    pi.multiaddr.add(mh4)
+
+    var distinctMultiaddr = pi.distinctMultiaddr()
+    expect(distinctMultiaddr.length).to.equal(2)
+
+    expect(distinctMultiaddr[0].toOptions().family).to.equal('ipv4')
+    expect(distinctMultiaddr[1].toOptions().family).to.equal('ipv6')
+  })
 })


### PR DESCRIPTION
This method can be called from libp2p-swarm/lib/transport.js just before the createListeners method is called and may be a solution to issue https://github.com/ipfs/js-ipfs/issues/228.  This method returns an array of multiaddr which are distinct by port.  Transport is not considered, if there are two transports with the same port the first multiaddr will be returned.

Question:
1. Does this seem like a resonable solution?
2. Should both port and transport be used to determine what is distinct?