### PR TITLE
chore(package): make engines npm valid, like js-ipfs-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "engines": {
     "node": ">=6.0.0",
-    "npm": ">=6.0.0"
+    "npm": ">=3.0.0"
   },
   "author": "David Dias <daviddias@ipfs.io>",
   "license": "MIT",


### PR DESCRIPTION
```
user@host $ npm install --save ipfs-api
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for peer-info@0.11.0: wanted: {"node":">=6.0.0","npm":">=6.0.0"} (current: {"node":"8.4.0","npm":"5.3.0"})
npm ERR! notsup Not compatible with your version of node/npm: peer-info@0.11.0
npm ERR! notsup Not compatible with your version of node/npm: peer-info@0.11.0
npm ERR! notsup Required: {"node":">=6.0.0","npm":">=6.0.0"}
npm ERR! notsup Actual:   {"npm":"5.3.0","node":"8.4.0"}
```

There is no npm >=6.0.0, this is likely a typo. 

```
yarn add ipfs-api --ignore-engine
```

Will work around this issue, but because yarn does not respect nested node_modules the same way, it is necessary for me to use npm to install ipfs-api.

