### PR TITLE
Add flow type signatures.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,9 @@
+[ignore]
+.*/node_modules/documentation/*
+.*/node_modules/node_modules/radium/*
+
+[libs]
+
+[include]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "multiaddr": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
-    "peer-id": "~0.10.3"
+    "peer-id": "~0.10.3",
+    "callback.flow": "^1.0.0"
   },
   "contributors": [
     "Arnaud <arnaud.valensi@gmail.com>",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,19 @@
+// @flow
+
+import type { Callback } from "callback.flow"
+import type { PeerId, JSONPeerId } from "peer-id"
+import type { MultiaddrSet, Address } from "./multiaddr-set"
+
+export interface PeerInfo {
+  id: PeerId;
+  multiaddrs: MultiaddrSet;
+  connect(Address): void;
+  disconnect(): void;
+  isConnected(): boolean;
+}
+
+declare export default {
+  create(Callback<Error, PeerInfo>): void,
+  create(PeerId | JSONPeerId, Callback<Error, PeerInfo>): void,
+  isPeerInfo(mixed): boolean
+}

--- a/src/multiaddr-set.js.flow
+++ b/src/multiaddr-set.js.flow
@@ -1,0 +1,22 @@
+// @flow
+
+import type { Multiaddr } from "multiaddr"
+
+export type { Multiaddr }
+export type Address = Multiaddr | Buffer | string
+
+export interface MultiaddrSet {
+  add(Address): void;
+  addSafe(Address): void;
+  toArray(): Multiaddr[];
+  forEach(fn: (Multiaddr, index?: number) => mixed): void;
+  has(Address): boolean;
+  delete(Address): void;
+  replace(existing: Address, fresh: Address): void;
+  clear(): void;
+  distinct(): Multiaddr[];
+}
+
+declare export default {
+  (multiaddrs?: Multiaddr[]): MultiaddrSet
+}

--- a/src/utils.js.flow
+++ b/src/utils.js.flow
@@ -1,0 +1,7 @@
+// @flow
+
+import type { Multiaddr } from "multiaddr"
+
+declare export var ensureMultiaddr: (
+  address: string | Buffer | Multiaddr
+) => Multiaddr


### PR DESCRIPTION
As dive into ipfs / libp2p code base I struggle to guess what are all the things passed around. Types as in [flow](http://flow.org/) (or typescript for that matter) simplify learning of how things are connected significantly. There for I decided to contribute type signatures to the code base as I digg through it. 

### What's up with all these .js.flow files ?

Unfortunately flow project has yet to come up with coherent story of how to provide type annotations for third party libraries. In my experience adding `.js.flow` files works best out of all options, that is because flow type checker when gives a precedent to `/path/to/file.js.flow` over `/path/to/file.js` which essentially provides a way to provide type annotations for non-flow typed package such that just using it as dependency will satisfy both type checker and run-time.

It's far from ideal given that `.js` and `.js.flow` files can get out of sync but then again unless you're open to adopt flow this is the best option IMO.

### Depends on https://github.com/libp2p/js-peer-id/pull/75

  
  