### PR TITLE
add filter functionality for multiaddr

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
-    "multiaddr": "^3.0.2",
+    "js-mafmt": "^1.0.0",
     "lodash.uniqby": "^4.7.0",
+    "multiaddr": "^3.0.2",
     "peer-id": "~0.10.5"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
-    "js-mafmt": "^1.0.0",
     "lodash.uniqby": "^4.7.0",
+    "mafmt": "^4.0.0",
     "multiaddr": "^3.0.2",
     "peer-id": "~0.10.5"
   },

--- a/src/multiaddr-set.js
+++ b/src/multiaddr-set.js
@@ -52,6 +52,10 @@ class MultiaddrSet {
     return this._multiaddrs.forEach(fn)
   }
 
+  filter (fn) {
+    return this._multiaddrs.filter(fn)
+  }
+
   has (ma) {
     ma = ensureMultiaddr(ma)
     return this._multiaddrs.some((m) => m.equals(ma))

--- a/src/multiaddr-set.js
+++ b/src/multiaddr-set.js
@@ -52,8 +52,13 @@ class MultiaddrSet {
     return this._multiaddrs.forEach(fn)
   }
 
-  filter (fn) {
-    return this._multiaddrs.filter(fn)
+  filterBy (maFmt) {
+    if (typeof maFmt !== 'object' ||
+      typeof maFmt.matches !== 'function' ||
+      typeof maFmt.partialMatch !== 'function' ||
+      typeof maFmt.toString !== 'function') return []
+
+    return this._multiaddrs.filter((ma) => maFmt.matches(ma))
   }
 
   has (ma) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,6 +7,7 @@ chai.use(dirtyChai)
 const expect = chai.expect
 const Id = require('peer-id')
 const Multiaddr = require('multiaddr')
+const mafmt = require('mafmt')
 const Info = require('../src')
 const peerIdJSON = require('./peer-test.json')
 
@@ -260,12 +261,12 @@ describe('peer-info', () => {
     })
   })
 
-  it('multiaddrs.filter', () => {
+  it('multiaddrs.filterBy', () => {
     const ma1 = Multiaddr('/ip4/127.0.0.1/tcp/7000')
-    const ma2 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    const ma2 = Multiaddr('/ip4/127.0.0.1/udp/5001')
     pi.multiaddrs.add(ma1)
     pi.multiaddrs.add(ma2)
-    const maddrs = pi.multiaddrs.filter((ma) => (ma.equals(ma1)))
+    const maddrs = pi.multiaddrs.filterBy(mafmt.TCP)
     expect(maddrs.length).to.eq(1)
     expect(maddrs[0].equals(ma1)).to.eq(true)
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -260,6 +260,16 @@ describe('peer-info', () => {
     })
   })
 
+  it('multiaddrs.filter', () => {
+    const ma1 = Multiaddr('/ip4/127.0.0.1/tcp/7000')
+    const ma2 = Multiaddr('/ip4/127.0.0.1/tcp/5001')
+    pi.multiaddrs.add(ma1)
+    pi.multiaddrs.add(ma2)
+    const maddrs = pi.multiaddrs.filter((ma) => (ma.equals(ma1)))
+    expect(maddrs.length).to.eq(1)
+    expect(maddrs[0].equals(ma1)).to.eq(true)
+  })
+
   it('multiaddrs.toArray', () => {
     pi.multiaddrs.add('/ip4/127.0.0.1/tcp/5001')
     pi.multiaddrs.toArray().forEach((ma) => {


### PR DESCRIPTION
This is in regards to #7 , it seems like adding a filter capability to multiaddrs in PeerInfo would be a step in the right direction, maybe all that's really needed. Downstream request become something like
```js
pInfo.multiaddrs.filter((ma)=>mafmt.UDP.matches(ma)) 
```
 For more complex slices it seems as though maybe js-mafmt should expose or/and, so people can define their own valid slices of protocols, then refer to them as needed if that make sense. @diasdavid  what do you think, not sure if this is inline with what you had in mind :), open to suggestions thoughts.