### PR TITLE
feat: add support for multiaddrs on create

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - os: windows
+      cache: false
+
+    - stage: check
+      script:
+        - npx aegir commitlint --travis
+        - npx aegir dep-check
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script: npx aegir test -t browser -t webworker
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script: npx aegir test -t browser -t webworker -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # js-peer-info
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Build Status](https://travis-ci.org/libp2p/js-peer-info.svg?style=flat-square)](https://travis-ci.org/libp2p/js-peer-info)
-[![Coverage Status](https://coveralls.io/repos/github/libp2p/js-peer-info/badge.svg?branch=master)](https://coveralls.io/github/libp2p/js-peer-info?branch=master)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![](https://img.shields.io/codecov/c/github/libp2p/js-peer-info.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-peer-info)
+[![](https://img.shields.io/travis/libp2p/js-peer-info.svg?style=flat-square)](https://travis-ci.com/libp2p/js-peer-info)
 [![Dependency Status](https://david-dm.org/libp2p/js-peer-info.svg?style=flat-square)](https://david-dm.org/libp2p/js-peer-info)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
-[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![](https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square)
-![](https://img.shields.io/badge/Node.js-%3E%3D6.0.0-orange.svg?style=flat-square)
 
 ## Lead Maintainer
 

--- a/README.md
+++ b/README.md
@@ -88,18 +88,20 @@ const PeerInfo = require('peer-info')
 
 ### `PeerInfo.create([id, ] callback)`
 
-- `id` optional - can be a PeerId or a JSON object(will be parsed with https://github.com/libp2p/js-peer-id#createfromjsonobj) 
+- `id` optional - can be a PeerId or a JSON object(will be parsed with https://github.com/libp2p/js-peer-id#createfromjsonobj)
 - `callback: Function` with signature `function (err, peerInfo) {}`
 
 Creates a new PeerInfo instance and if no `id` is passed it
 generates a new underlying [PeerID](https://github.com/libp2p/js-peer-id)
 for it.
 
-### `new PeerInfo(id)`
+### `new PeerInfo(id, addrs)`
 
-- `id: PeerId` - instance of PeerId (optional)
+- `id: PeerId` - instance of PeerId
+- `addrs: Array<Multiaddr>` - an array of Multiaddr's (optional)
 
-Creates a new PeerInfo instance from an existing PeerId.
+Creates a new PeerInfo instance from an existing PeerId. If the multiaddr array
+is provided, it will seed [`.multiaddrs`](#multiaddrs).
 
 ### `protocols`
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,16 @@ const assert = require('assert')
 
 // Peer represents a peer on the IPFS network
 class PeerInfo {
-  constructor (peerId) {
+  /**
+   * @constructor
+   * @param {PeerId} peerId
+   * @param {Array<Multiaddr>} addrs
+   */
+  constructor (peerId, addrs = []) {
     assert(peerId, 'Missing peerId. Use Peer.create(cb) to create one')
 
     this.id = peerId
-    this.multiaddrs = new MultiaddrSet()
+    this.multiaddrs = new MultiaddrSet(addrs)
 
     /**
      * Stores protocols this peers supports

--- a/src/multiaddr-set.js
+++ b/src/multiaddr-set.js
@@ -5,8 +5,12 @@ const uniqBy = require('unique-by')
 
 // Because JavaScript doesn't let you overload the compare in Set()..
 class MultiaddrSet {
-  constructor (multiaddrs) {
-    this._multiaddrs = multiaddrs || []
+  /**
+   * @constructor
+   * @param {Array<Multiaddr>} multiaddrs
+   */
+  constructor (multiaddrs = []) {
+    this._multiaddrs = multiaddrs.map((ma) => ensureMultiaddr(ma))
     this._observedMultiaddrs = []
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -78,6 +78,15 @@ describe('peer-info', () => {
     })
   })
 
+  it('should be able to provide multiaddrs on create', () => {
+    const addrs = [
+      Multiaddr('/ip4/127.0.0.1/tcp/5001'),
+      Multiaddr('/ip4/127.0.0.1/tcp/5002/ws')
+    ]
+    const peerInfo = new Info(pi.id, addrs)
+    expect(peerInfo.multiaddrs.toArray()).to.eql(addrs)
+  })
+
   it('add multiaddr', () => {
     const ma = Multiaddr('/ip4/127.0.0.1/tcp/5001')
     pi.multiaddrs.add(ma)


### PR DESCRIPTION
This backwards compatible change allows users to seed the multiaddr set with known multiaddrs on PeerInfo creation. This prevents the need to do `.add` for known addresses.
```js
const peerInfo = new PeerInfo(id)
knownAddrs.forEach((addr) => peerInfo.multiaddrs.add(addr))
```
and you can instead just do:
```js
const peerInfo = new PeerInfo(id, knownAddrs)
```

Since the multiaddrs are verified as multiaddrs on creation you can also use an array of strings or buffers.
```js
new PeerInfo(id, [
  '/ip4/0.0.0.0/tcp/0',
  '/ip4/0.0.0.0/tcp/0/ws'
])
```

## Other things
* Moved over to Travis CI. (I also disabled appveyor to avoid false ci failure checks from there)
* Updated the badges in the readme to match style updates happening elsewhere in js-libp2p