### PR TITLE
fix: distinct should work for non port addresses

### DIFF
--- a/src/multiaddr-set.js
+++ b/src/multiaddr-set.js
@@ -99,7 +99,11 @@ class MultiaddrSet {
   // in libp2p-tcp
   distinct () {
     return uniqBy(this._multiaddrs, (ma) => {
-      return [ma.toOptions().port, ma.toOptions().transport].join()
+      const options = ma.toOptions()
+      if (options.port === undefined) {
+        return ma.toString()
+      }
+      return [options.port, options.transport].join()
     })
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -248,6 +248,17 @@ describe('peer-info', () => {
     expect(multiaddrDistinct[1].toOptions().family).to.equal('ipv6')
   })
 
+  it('get distinct multiaddr when port doesnt exist', () => {
+    const ma1 = Multiaddr('/unix/a/b/c/d/e')
+    const ma2 = Multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+
+    pi.multiaddrs.add(ma1)
+    pi.multiaddrs.add(ma2)
+
+    const multiaddrDistinct = pi.multiaddrs.distinct()
+    expect(multiaddrDistinct.length).to.equal(2)
+  })
+
   it('multiaddrs.has', () => {
     pi.multiaddrs.add('/ip4/127.0.0.1/tcp/5001')
     expect(pi.multiaddrs.has('/ip4/127.0.0.1/tcp/5001')).to.equal(true)


### PR DESCRIPTION
This fixes an issue with `.distinct()` being called when the addresses do not have ports. It's entirely valid to have an address that doesn't have a port, so we should just treat the entirety of those addresses as unique. 

Note, as mentioned in comments in `distinct` this logic doesn't really belong in PeerInfo. When we implement https://github.com/libp2p/interface-transport/issues/41 for transports, it should handle distinct addresses when listening. This is a stop gap until that is complete.

required by https://github.com/ipfs/interop/issues/63