### PR TITLE
chore: upgrade js multiaddr

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "mafmt": "^6.0.9",
-    "multiaddr": "^6.1.0",
+    "multiaddr": "^7.1.0",
     "peer-id": "~0.13.2",
     "unique-by": "^1.0.0"
   },


### PR DESCRIPTION
to release as v0.17.0