### PR TITLE
fix: remove use of assert module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,13 @@
 const PeerId = require('peer-id')
 const { ensureMultiaddr } = require('./utils')
 const MultiaddrSet = require('./multiaddr-set')
-const assert = require('assert')
 
 // Peer represents a peer on the IPFS network
 class PeerInfo {
   constructor (peerId) {
-    assert(peerId, 'Missing peerId. Use Peer.create() to create one')
+    if (!peerId) {
+      throw new Error('Missing peerId. Use Peer.create() to create one')
+    }
 
     this.id = peerId
     this.multiaddrs = new MultiaddrSet()


### PR DESCRIPTION
The polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.